### PR TITLE
Add module method

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,10 @@ interface Compartment {
   async import(specifier: string): Promise<{namespace: ModuleNamespace}>;
   // Desired by TC53
   importNow(specifier: string): ModuleNamespace;
+  // Necessary to thread a module exports namespace from this compartment into
+  // the `moduleMap` Compartment constructor argument, without importing (and
+  // consequently executing) the module.
+  module(specifier: string): ModuleNamespace;
 }
 ```
 


### PR DESCRIPTION
This adds a note to flesh out in a later change the addition of a `module` method to compartments to allow inter-compartment linkage to be planned and possibly loaded without necessarily execution.