### PR TITLE
Document endowments as PropertyDescriptors

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,9 +142,9 @@ type CompartmentConstructorOptions = {
 //                6.1.7.4 Well-Known Intrinsic Objects
 interface Compartment {
   constructor(
-    // extra bindings added to the global
+    // extra bindings added to the globalThis of the compartment
     endowments?: {
-      [globalPropertyName: string]: any
+      [globalPropertyName: string]: PropertyDescriptor
     },
     // need to figure out module attributes as it progresses
     // maps child specifier to parent specifier


### PR DESCRIPTION
Currently `endowments` are documented as `any`.

I guess it means:

```js
const comp = new Compartment({ something: 1 })
comp.globalThis.something === 1
```

I suggest changing it to PropertyDescriptors:

```js
const comp = new Compartment({
    location: { value: new MockLocation(import.meta.url), configurable: false, enumerable: true, writable: false }
})
comp.globalThis.location = '' // No
```