### PR TITLE
Guest shares host by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -537,6 +537,61 @@ Implementations must take care to ensure that the module record memo and the
 module record *promise* memo point to the same record for a given ultimate full
 specifier.
 
+
+### Bundling or archiving
+
+Compartments can be employed to virtualize a foreign environment and generate
+bundles, archives, or other stored forms of a program for transmission and
+deferred execution.
+
+This first snippet is a minimal bundler.
+It differs from the first minimal example only in that it generates a `sources`
+Map and calls `load` instead of `import`, ensuring we do not attempt to run any
+of the loaded code locally.
+
+```js
+const sources = new Map();
+const compartment = new Compartment({
+  resolveHook(importSpecifier, referrerSpecifier) {
+    return new URL(importSpecifier, referrerSpecifier).href;
+  },
+  async loadHook(fullSpecifier) {
+    const response = await fetch(fullSpecifier);
+    const source = await response.text();
+    sources.set(fullSpecifier, source);
+    return {
+      record: new StaticModuleRecord(source),
+      meta: { url: response.url },
+    };
+  },
+});
+await compartment.load('https://example.com/example.js');
+```
+
+Then, we presumably serialize the `sources` map and recreate it in another
+environment.
+This next figure uses the `sources` to reconstruct the original compartment
+compartment module graph and execute it.
+
+```js
+const evaluator = new Compartment({
+  resolveHook(importSpecifier, referrerSpecifier) {
+    return new URL(importSpecifier, referrerSpecifier).href;
+  },
+  loadHook(fullSpecifier) {
+    const source = sources.get(fullSpecifier);
+    if (source === undefined) {
+      throw new Error('Assertion failed: incomplete sources');
+    }
+    return {
+      record: new StaticModuleRecord(source),
+      meta: { url: response.url },
+    };
+  },
+});
+await evaluator.import('https://example.com/example.js');
+```
+
 ### Thenable Module Hazard
 
 An exported value named `then` can be statically imported, but dynamic import

--- a/README.md
+++ b/README.md
@@ -133,6 +133,41 @@ Below is a rough sketch of potential interfaces.
   The environment record does not contain a property for any names that are
   imported and reexported without a lexical binding.
 
+A compartment privately retains references to:
+
+* A global object
+* A global environment record
+* A static module record promise memo
+* A static module record memo
+* A module instance promise memo
+* A module instance memo
+* A resolve hook
+* A load hook
+* An import meta hook
+
+Every realm retains in itself an intrinsic compartment, with a host-defined global
+environment, resolve hook, load hook, and import meta hook.
+Every constructed compartment (guest) by default shares the global object, global
+environment record, resolve hook, load hook, and *static* memos of its host.
+Compartment constructor options may override these defaults.
+
+Compartments accept a `globals` option.
+If provided, the guest compartment will create its own empty global object with a
+null prototype and derive its own global environment record from that object.
+The compartment will then create an intrinsic `eval`, `Function`, and `Compartment` that
+refer back to the global environment record, such that scripts and modules
+evaluated in the compartment share this global environment record and such that
+direct `eval` in the compartment can succeed.
+The compartment then copies the enumerable own properties of the `globals` option
+onto the new `globalThis` using `[[Set]]`.
+
+The Compartment constructor accepts host-virtualization hooks for loading behavior
+including a `resolveHook`, `loadHook`, `importMetaHook`,and a `modules` record.
+If a Compartment constructor receives any of these options, the Compartment constructor
+will prepare new, empty memos, and adopt the provided host-virtualization hooks.
+The `loadHook` can still adopt entries from the host's memos by returning
+a descriptor that refers to them by their full specifier.
+
 ```ts
 type ModuleExportsNamespace = Record<string, unknown>;
 type ModuleEnvironmentRecord = Record<string, unknown>;
@@ -314,29 +349,6 @@ type ModuleDescriptor =
   };
 
 type CompartmentConstructorOptions = {
-  // Every Compartment has a reference to a global environment record that in
-  // turn contains a new globalThis object, global contour, and three
-  // specialized intrinsic evaluators: eval, Function, and Compartment instances.
-  // The new globalThis object contains a subset of the JavaScript language
-  // intrinsics (to be defined in this proposal) and other globals must be
-  // "endowed" to the compartment explicitly with the `globals` option.
-  // All of these evaluators close over the compartment's global environment
-  // record such that they evaluate code in that global environment.
-  // When borrowGlobals is false, a the new Compartment gets a new global
-  // environment record.
-  // When borrowGlobals is true, the new Compartment will have the
-  // same global environment record as associated with the Compartment
-  // constructor used to construct the compartment.
-  // To borrow the globals of an arbitrary compartment, use that compartment's
-  // Compartment constructor, like
-  // new compartment.globalThis.Compartment({ borrowGlobals: true }).
-  borrowGlobals: boolean,
-
-  // Globals to copy onto this compartment's unique globalThis.
-  // Constructor options with globals and borrowGlobals: true would be incoherent and
-  // effect an exception.
-  globals: Object,
-
   // The compartment uses the resolveHook to synchronously elevate
   // an import specifier (as it appears in the source of a StaticModuleRecord
   // or bindings array of a SyntheticStaticModuleRecord), to
@@ -372,6 +384,12 @@ type CompartmentConstructorOptions = {
   // so some work can be deferred until just before the compartment
   // initializes the module.
   importMetaHook?: (fullSpecifier: string, importMeta: Object) => void,
+
+  // Causes the guest compartment to create its own globalThis instead of sharing
+  // its host's.
+  // The constructor copies the own properties over its own globalThis by
+  // assignment.
+  globals: Object,
 };
 
 interface Compartment {
@@ -381,14 +399,6 @@ interface Compartment {
   constructor(options?: CompartmentConstructorOptions): Compartment;
 
   // Accessor for this compartment's globals.
-  // If borrowGlobals is true, globalThis is object identical to the incubating
-  // compartment's globalThis.
-  // If borrowGlobals is false, globalThis is a unique, ordinary object
-  // intrinsic to this compartment.
-  // The globalThis object initially has only "shared intrinsics",
-  // followed by compartment-specific "eval", "Function", and "Compartment",
-  // followed by any properties transferred from the "globals"
-  // constructor option with the semantics of Object.assign.
   globalThis: Object,
 
   // Evaluates a program program using this compartment's associated global

--- a/README.md
+++ b/README.md
@@ -592,6 +592,68 @@ const evaluator = new Compartment({
 await evaluator.import('https://example.com/example.js');
 ```
 
+### Inter-compartment linkage
+
+One motivating use of compartments is to isolate Node.js-style packages and
+limit their access to powerful modules and globals, to mitigate software supply
+chain attacks.
+With such an application, we would construct a special compartment for each package
+and allow compartments to link modules across compartment boundaries.
+
+In this trivial example, we construct a pair of compartments, `even` and `odd`,
+which in turn contain mutually dependent `even` and `odd` modules that
+participate in a dependency cycle.
+For simplicity, the domain of module specifiers is exactly the names `even` and
+`odd`, and these compartments do not support resolution.
+
+These compartments use `{ instance, compartment }` module descriptors to indicate
+linkage across compartment boundaries.
+
+```js
+const even = new Compartment({
+  resolveHook: specifier => specifier,
+  loadHook: async specifier => {
+    if (specifier === 'even') {
+      return { record: new StaticModuleRecord(`
+        import isOdd from 'odd';
+        export default n => n === 0 || isOdd(n - 1);
+      `) };
+    } else if (specifier === 'odd') {
+      return { instance: specifier, compartment: odd };
+    } else {
+      throw new Error(`No such module ${specifier}`);
+    }
+  },
+});
+
+const odd = new Comaprtment({
+  resolveHook: specifier => specifier,
+  loadHook: async specifier => {
+    if (specifier === 'odd') {
+      return { record: new StaticModuleRecord(`
+        import isEven from 'even';
+        export default n => n !== 0 && isEven(n - 1);
+      `) };
+    } else if (specifier === 'even') {
+      return { instance: specifier, compartment: even };
+    } else {
+      throw new Error(`No such module ${specifier}`);
+    }
+  },
+});
+```
+
+An alternative design that Agoric's SES shim and XS's native Compartment
+explored used module exports namespace objects as handles that could be passed
+between compatment hooks.
+However, to support the bundler use case, it became necessary to add a method
+that could get a module exports namespace object for a module that had not yet
+been loaded (`compartment.module(specifier)`, much less instantiated, nor
+initialized.
+The invention of a module descriptor allowed us to remove this complication,
+among others: the `moduleMapHook` became superfluous since both the `modules`
+constructor option and the `loadHook` could use module descriptors instead.
+
 ### Linking with a synthetic record (JSON example)
 
 To support non-JavaScript languages, a compartment provides a `loadHook` that


### PR DESCRIPTION
This proposal would change the default behavior of the Loader constructor such that it creates a useful guest `Loader` by default, by sharing the host’s global object, static memos, and hooks. Loader constructor options override these behaviors selectively.

The motivation for this case is to provide a direct answer to @guybedford and @lucacasonato who proposed that one of the requirements for WASM is the ability to defer execution of a WASM module such that it be linked in a new module graph, possibly in multiple module graphs. This aligns well with the needs for Hot Module Replacement.

I propose as a straw-man that this framing of the Loader API would make possible a very clear way to express the designed intent:

```js
import static 'x.wasm';
for (let i = 0; i < poolSize; i++) {
  new Loader().import('x.wasm');
}
```

The `import static` declaration would defer execution but populate the static module record memo of the host’s realm loader with `x.wasm` and its transitive dependencies. The guest compartments would inherit these static module records by default.

Developing beyond this idea, host virtualization hooks on the loader can interpose to provide alternate linkage or fall through to the host. In this example, the new loader would inherit the instance of `'y.wasm'`, which we presume `'x.wasm'` imports. Consequently, the new loader has its own instance of `x.wasm` and an instance of `y.wasm` shared with the host.

```js
new Loader({
  loadHook(fullSpecifier) {
    if (fullSpecifier === 'y.wasm') {
      return { instance: fullSpecifier };
    } else {
      return { record: fullSpecifier };
    }
  },
}).import('x.wasm');
```