### PR TITLE
Reify module instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -593,6 +593,31 @@ await compartment.load('./thenable.js');
 const thenableNamespace = compartment.importNow('./thenable.js');
 ```
 
+# Encapsulate or reveal ModuleInstance
+
+This proposal tenatively hides `%ModuleInstance%` and `%Global%`.
+A coherent alternate to this design could reveal both of these and hide
+`Compartment`.
+However, a language-defined loader is better positioned to maintain
+the invariant that dynamic and static import in a module should
+consistently bind the same module instance to the same module specifier from
+within a particular referrer module.
+A reified `ModuleInstance` constructor would need to accept an arbitrary
+dynamic import hook.
+
+One motivation for revealing `ModuleInstance` would be to avoid
+litigating the complications of a `Compartment` definition.
+However, given that loader behavior is necessarily already specified
+as part of the definition of a realm, there is no version of
+this proposal that can omit `Compartment` entirely.
+
+It might, however, be possible to hide `%Compartment%` and avoid specifying module
+descriptors.
+Although that is an attractive simplification, Module descriptors are necessary
+for embedded systems, such that a static module record may pass from a host
+loader to a guest loader by name, without a JavaScript representation, and
+useful even when not necessary.
+
 [browserify]: https://browserify.org/
 [import-map]: https://github.com/WICG/import-maps
 [jest-ses-interaction]: https://github.com/facebook/jest/issues/11952


### PR DESCRIPTION
In this change, I propose the reification of ModuleInstance per @guybedford and @lucacasonato’s presentation at TC39 plenary today, June 8th. The premise is that ejecting ModuleInstance would allow us defer the definition of Loader to user-code, that `StaticModuleRecord` and `ModuleInstance` (by any other name) should be sufficient to construct a loader.

I found that I was unable to eliminate `Loader` from the design for two reasons:

1. Dynamic import ultimately needs to defer to a Loader.
2. Hardened JavaScript isolation of shared intrinsics requires a JavaScript object to serve as a token representing the global environment in which each module should be evaluated. Direct eval in turn requires that global environment record to check whether the lexical name `eval` corresponds to the intrinsic `eval` for that environment.

